### PR TITLE
Fix header row handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,8 +4,8 @@ require_once __DIR__ . '/fetch_questions.php';
 // Convert raw CSV rows into an array with 'question' and 'choices' keys
 $formatted = [];
 foreach ($questions as $i => $row) {
-    // Skip header row if it contains text like "Question" or "\xE5\x95\x8F\xE9\xA1\x8C"
-    if ($i === 0 && isset($row[0]) && preg_match('/(question|\xE5\x95\x8F)/i', $row[0])) {
+    // Skip header row returned from the CSV
+    if ($i === 0) {
         continue;
     }
 


### PR DESCRIPTION
## Summary
- skip the header row from the CSV when formatting questions

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e789b620c8321ac6a3ce07d1bd538