### PR TITLE
Fix JSON script injection issue in quiz

### DIFF
--- a/index.php
+++ b/index.php
@@ -57,7 +57,9 @@ $questions = $formatted;
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-const questions = <?php echo json_encode($questions, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES); ?>;
+const questions = <?php echo json_encode($questions,
+    JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG);
+?>;
 let current = 0;
 
 const qEl = document.getElementById('question');


### PR DESCRIPTION
## Summary
- escape `<script>` tags when embedding question data

## Testing
- `php test_parse.php`


------
https://chatgpt.com/codex/tasks/task_e_684f7421695c83219f7283c455b1fc3c