### PR TITLE
Add localStorage progress tracking and id test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,18 @@ Run the included script to verify that multiline cells are handled correctly:
 ```bash
 php test_parse.php
 ```
+
+Another script ensures the formatted questions produced by `quiz_utils.php`
+contain an `id` field:
+
+```bash
+php test_format.php
+```
+
+## Progress storage
+
+Your current question index is stored in the browser using `localStorage` under
+the key `current`. When the page is reloaded it resumes from that index. To
+reset your progress, open your browser's developer tools, locate the
+`localStorage` entry for the site and remove the `current` item (or clear all
+stored data).

--- a/index.php
+++ b/index.php
@@ -27,7 +27,10 @@ require_once __DIR__ . '/fetch_questions.php';
 const questions = <?php echo json_encode($questions,
     JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG);
 ?>;
-let current = 0;
+let current = parseInt(localStorage.getItem('current') || '0', 10);
+if (isNaN(current) || current < 0 || current >= questions.length) {
+    current = 0;
+}
 
 const qEl = document.getElementById('question');
 const metaEl = document.getElementById('meta');
@@ -47,6 +50,7 @@ function escapeHtml(str) {
 }
 
 function showQuestion() {
+    localStorage.setItem('current', current);
     const q = questions[current];
     qEl.innerHTML = escapeHtml(q.question).replace(/\n/g, '<br>');
     metaEl.textContent = q.meta || '';
@@ -120,6 +124,7 @@ function nextQuestion() {
         expEl.textContent = '';
         submitBtn.style.display = 'none';
         nextBtn.style.display = 'none';
+        localStorage.removeItem('current');
         return;
     }
     showQuestion();

--- a/quiz_utils.php
+++ b/quiz_utils.php
@@ -28,6 +28,7 @@ function formatMeta(string $yearRound, string $number): string {
 
 function formatQuestions(array $rows): array {
     $formatted = [];
+    $id = 1;
     foreach ($rows as $i => $row) {
         if ($i === 0) {
             continue; // header
@@ -51,6 +52,7 @@ function formatQuestions(array $rows): array {
         $explanation = $row[9] ?? '';
 
         $formatted[] = [
+            'id'          => $id++,
             'question'    => $questionText,
             'choices'     => $choices,
             'answer'      => $answer,

--- a/test_format.php
+++ b/test_format.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/quiz_utils.php';
+
+$csv = <<<CSV
+"試験年度・回数","出題方式","問題番号","問題文","選択肢1","選択肢2","選択肢3","選択肢4","正答","解説"
+"R5-4","○×","1","次の HTML において、ロゴ画像の代替テキストは適切である。\n<p>\n<img src=\"logo.png\" alt=\"インターネットスキル認定普及協会\">\nインターネットスキル認定普及協会\n</p>","正しい","正しくない","","","2","ロゴであることも簡潔に盛り込むべき"
+"R5-4","○×","2","title 要素はメタデータコンテンツである。","正しい","正しくない","","","1",""
+CSV;
+
+$rows = [];
+$handle = fopen('php://temp', 'r+');
+fwrite($handle, $csv);
+rewind($handle);
+while (($row = fgetcsv($handle)) !== false) {
+    $rows[] = $row;
+}
+fclose($handle);
+
+$questions = formatQuestions($rows);
+$missingId = false;
+foreach ($questions as $q) {
+    if (!isset($q['id'])) {
+        $missingId = true;
+        break;
+    }
+}
+if ($missingId) {
+    echo "id field missing\n";
+    exit(1);
+}
+
+echo "All questions include id field\n";
+?>


### PR DESCRIPTION
## Summary
- persist quiz progress in `localStorage` so users can reload and resume
- document how to reset quiz progress by clearing `localStorage`
- add unique `id` to formatted questions
- provide `test_format.php` to verify the `id` field

## Testing
- `php test_parse.php`
- `php test_format.php`


------
https://chatgpt.com/codex/tasks/task_e_684f910e301883219132888d3dea58dd