### PR TITLE
Implement review mode for quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ contain an `id` field:
 php test_format.php
 ```
 
+The `test_review.js` script verifies the logic around the new review mode
+without requiring all 200 questions:
+
+```bash
+node test_review.js
+```
+
 The quiz contains 200 questions in total (40 questions for each of the last five
 years). Your progress line shows how many answers you've gotten correct out of
 the number of questions you have attempted so far, along with your accuracy and
@@ -27,8 +34,11 @@ how many questions remain. For example:
 ## Progress storage
 
 The app stores the IDs of questions you have answered in `localStorage` under
-the key `solved`. The number of correct answers is stored under `score`. When
-the page loads it filters out any solved questions and serves one of the
-remaining questions at random. To reset your progress, open your browser's
-developer tools and remove both the `solved` and `score` entries (or clear all
-stored data).
+the key `solved`. The number of correct answers is stored under `score`. IDs of
+incorrectly answered questions are stored under `incorrect`. Enable "復習モード"
+using the switch on the page to practice only those questions. Correct answers
+in this mode remove the corresponding ID from `incorrect` so you can repeat
+until all are solved. When the page loads it filters questions according to the
+current mode. To reset your progress, open your browser's developer tools and
+remove the `solved`, `score` and `incorrect` entries (or clear all stored
+data).

--- a/test_review.js
+++ b/test_review.js
@@ -1,0 +1,45 @@
+const questions = [
+  {id: 1, answer: '1', choices: ['a', 'b']},
+  {id: 2, answer: '2', choices: ['c', 'd']}
+];
+
+let incorrectIds = [];
+let solvedIds = [];
+let score = 0;
+
+function processAnswer(q, selected) {
+  const correct = q.answer.trim();
+  const isCorrect = String(selected) === correct;
+  if (isCorrect) {
+    score++;
+    const idx = incorrectIds.indexOf(q.id);
+    if (idx !== -1) incorrectIds.splice(idx, 1);
+  } else {
+    if (!incorrectIds.includes(q.id)) incorrectIds.push(q.id);
+  }
+  if (!solvedIds.includes(q.id)) solvedIds.push(q.id);
+  return isCorrect;
+}
+
+// answer first question incorrectly
+processAnswer(questions[0], '2');
+if (incorrectIds.length !== 1 || incorrectIds[0] !== 1) {
+  console.error('Incorrect question not recorded');
+  process.exit(1);
+}
+
+// review mode should serve only question 1
+const reviewQs = questions.filter(q => incorrectIds.includes(q.id));
+if (reviewQs.length !== 1 || reviewQs[0].id !== 1) {
+  console.error('Review mode did not select incorrect question');
+  process.exit(1);
+}
+
+// answer it correctly in review
+processAnswer(reviewQs[0], '1');
+if (incorrectIds.length !== 0) {
+  console.error('Correct answer was not removed from incorrect list');
+  process.exit(1);
+}
+
+console.log('Review logic ok');


### PR DESCRIPTION
## Summary
- store incorrect answers in `localStorage`
- add "復習モード" toggle and question selection logic
- adjust progress display for review mode
- keep/remove incorrect questions when answered correctly
- add node test for review mode
- document review mode in README

## Testing
- `php test_parse.php`
- `php test_format.php`
- `node test_review.js`


------
https://chatgpt.com/codex/tasks/task_e_6852922f3ca0832184031a7652ac6746